### PR TITLE
Create executable picker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,5 +127,6 @@ dmypy.json
 *.idea
 .DS_STORE
 my_project
+*.pyc
 
 # End of https://www.gitignore.io/api/python

--- a/autonomy.py
+++ b/autonomy.py
@@ -178,17 +178,23 @@ def include_heading():
 
 # :param vehicle: vehicle object that represents drone
 # :param vehicle_type: vehicle type from configs file
-def update_thread(vehicle, vehicle_type, address):
+def update_thread(vehicle, configs, address, gcs_timestamp, connection_timestamp):
     print("Starting update thread\n")
     while not mission_completed:
         location = vehicle.location.global_frame
         battery_level = vehicle.battery.level / 100.0  # To comply with format of 0 - 1
         update_message = {
             "type": "update",
-            "vehicleType": vehicle_type,
+            "time": round(time.clock() - connection_timestamp) + gcs_timestamp,
+            "sid": configs["vehicle_id"],
+            "tid": 0, # the ID of the GCS is 0
+            "id": 0, # TODO make the IDs unique for acknowledgements
+
+            "vehicleType": "VTOL",
             "lat": location.lat,
             "lon": location.lon,
             "status": status,
+            # TODO heading
             "battery": battery_level
         }
 

--- a/comm_sim_detailed_search.txt
+++ b/comm_sim_detailed_search.txt
@@ -1,5 +1,5 @@
-1.0~{"type":"addMission","missionInfo":{"lat":34.917, "lon": 27.948}}
-2.0~{"type":"addMission","missionInfo":{"lat":5, "lon": 100.23}}
-3.0~{"type":"pause"}
-4.0~{"type":"resume"}
-5.0~{"type":"stop"}
+1.0~{"type":"addMission","missionInfo":{"lat":34.917, "lon": 27.948}, "id":0}
+2.0~{"type":"addMission","missionInfo":{"lat":5, "lon": 100.23}, "id":0}
+3.0~{"type":"pause", "id":0}
+4.0~{"type":"resume", "id":0}
+5.0~{"type":"stop", "id":0}

--- a/comm_sim_detailed_search.txt
+++ b/comm_sim_detailed_search.txt
@@ -1,4 +1,3 @@
-0.5~{"type":"start"}
 1.0~{"type":"addMission","missionInfo":{"lat":34.917, "lon": 27.948}}
 2.0~{"type":"addMission","missionInfo":{"lat":5, "lon": 100.23}}
 3.0~{"type":"pause"}

--- a/comm_sim_quick_scan.txt
+++ b/comm_sim_quick_scan.txt
@@ -1,3 +1,3 @@
-0.75~{"type":"addMission", "searchArea":{"center":[1, 1], "rad1":0, "rad2":100}}
-50.0~{"type":"pause"}
-60.0~{"type":"resume"}
+0.75~{"type":"addMission", "searchArea":{"center":[1, 1], "rad1":0, "rad2":100}, "id":0}
+50.0~{"type":"pause", "id":0}
+60.0~{"type":"resume", "id":0}

--- a/comm_sim_quick_scan.txt
+++ b/comm_sim_quick_scan.txt
@@ -1,4 +1,3 @@
-0.5~{"type":"start", "jobType" : "quickScan"}
 0.75~{"type":"addMission", "searchArea":{"center":[1, 1], "rad1":0, "rad2":100}}
 50.0~{"type":"pause"}
 60.0~{"type":"resume"}

--- a/configs.json
+++ b/configs.json
@@ -1,7 +1,8 @@
 {
   "vehicle_type": "Quadcopter",
-  "vehicle_name": "A",
+  "vehicle_id": 1,
   "vehicle_simulated": true,
+  "3dr_solo": false,
   "cv_simulated": {
     "toggled_on": true,
     "directory": "some/path/for/now/i/will/add/in/later/when/testing"
@@ -11,10 +12,10 @@
   "d_theta_rad": 0.392699,
   "flight_mode": "AUTO",
   "quick_scan_specific": {
-    "role_switching": true,
+    "role_switching": false,
     "comms_simulated": {
       "toggled_on": true,
-      "comm_sim_file": "comm_sim.txt"
+      "comm_sim_file": "comm_sim_quick_scan.txt"
     }
   },
   "detailed_search_specific": {

--- a/detailed_search.py
+++ b/detailed_search.py
@@ -34,14 +34,14 @@ class DetailedSearchAutonomyToCV:
         self.acknowledgementMutex = Lock()
         self.acknowledgementMutex = False
 
-def detailed_search(vehicle = None):
+def detailed_search(vehicle = None, gcs_timestamp = 0, connection_timestamp = 0):
     # Parse configs file
     configs = parse_configs(sys.argv)
 
     # Start autonomy and CV threads
     autonomyToCV = DetailedSearchAutonomyToCV()
     autonomy_thread = Thread(target = detailed_search_autonomy,
-                             args = (configs, autonomyToCV, vehicle))
+                             args = (configs, autonomyToCV, gcs_timestamp, connection_timestamp, vehicle))
     autonomy_thread.daemon = True
     autonomy_thread.start()
 
@@ -56,7 +56,6 @@ def detailed_search(vehicle = None):
     # Close XBee device
     if autonomy.xbee:
         autonomy.xbee.close()
-
 
 if __name__ == "__main__":
     detailed_search()

--- a/detailed_search_autonomy.py
+++ b/detailed_search_autonomy.py
@@ -91,13 +91,13 @@ def detailed_search_autonomy(configs, autonomyToCV, gcs_timestamp, connection_ti
         vehicle = connect(connection_string, wait_ready=True)
 
         # Starts the update thread
-        update = Thread(target=update_thread, args=(vehicle, configs, configs["mission_control_MAC"]))
+        update = Thread(target=update_thread, args=(vehicle, configs["mission_control_MAC"]))
         update.start()
 
         takeoff(vehicle, configs["altitude"])
     else:
         # Starts the update thread
-        update = Thread(target=update_thread, args=(vehicle, configs, configs["mission_control_MAC"]))
+        update = Thread(target=update_thread, args=(vehicle, configs["mission_control_MAC"]))
         update.start()
 
     vehicle.mode = VehicleMode("GUIDED")

--- a/detailed_search_autonomy.py
+++ b/detailed_search_autonomy.py
@@ -130,9 +130,10 @@ def detailed_search_autonomy(configs, autonomyToCV, gcs_timestamp, connection_ti
     change_status("ready")
     autonomy.mission_completed = True
 
+    update.join()
+
     # Wait for comm simulation thread to end
     if comm_sim:
         comm_sim.join()
-
-    update.join()
-    autonomy.xbee.close()
+    else:
+        autonomy.xbee.close()

--- a/detailed_search_autonomy.py
+++ b/detailed_search_autonomy.py
@@ -135,3 +135,4 @@ def detailed_search_autonomy(configs, autonomyToCV, gcs_timestamp, connection_ti
         comm_sim.join()
 
     update.join()
+    autonomy.xbee.close()

--- a/detailed_search_autonomy.py
+++ b/detailed_search_autonomy.py
@@ -81,7 +81,10 @@ def detailed_search_autonomy(configs, autonomyToCV, gcs_timestamp, connection_ti
             sitl = dronekit_sitl.start_default(lat=1, lon=1)
             connection_string = sitl.connection_string()
         else:
-            connection_string = "/dev/serial0"
+            if (configs["3dr_solo"]):
+                connection_string = "udpin:0.0.0.0:14550"
+            else:
+                connection_string = "/dev/serial0"
 
         # Connect to vehicle
         vehicle = connect(connection_string, wait_ready=True)

--- a/executable_picker.py
+++ b/executable_picker.py
@@ -32,6 +32,7 @@ def xbee_callback(message):
         elif msg_type == "start":
             # detach this callback so that the corresponding role can use its own callback
             xbee.del_data_received_callback(xbee_callback)
+            xbee.close()
 
             job_type = msg['jobType']
             if job_type == "quickScan":

--- a/executable_picker.py
+++ b/executable_picker.py
@@ -1,0 +1,76 @@
+'''
+The GCS allocates roles to vehicles. The purpose of this program is to connect to the GCS and then
+read a start message from the GCS, which contains a certain job_type. It then runs the
+corresponding VTOL program (quick scan, detailed search, guide) based on the start message
+'''
+from autonomy import setup_xbee, bad_msg
+from quick_scan import quick_scan
+from detailed_search import detailed_search
+from util import parse_configs
+import sys
+import json
+import time
+
+xbee = None
+gcs_timestamp = 0
+connection_timestamp = 0
+
+def xbee_callback(message):
+    global gcs_timestamp
+    global connection_timestamp
+
+    address = message.remote_device.get_64bit_addr()
+    msg = json.loads(message.data)
+
+    try:
+        msg_type = msg["type"]
+
+        if msg_type == "connectionAck":
+            gcs_timestamp = msg['clocktime']
+            connection_timestamp = time.time()
+            
+        elif msg_type == "start":
+            # detach this callback so that the corresponding role can use its own callback
+            xbee.del_data_received_callback(xbee_callback)
+
+            job_type = msg['jobType']
+            if job_type == "quickScan":
+                quick_scan(gcs_timestamp = gcs_timestamp, connection_timestamp = connection_timestamp)
+            elif job_type == "detailedSearch":
+                detailed_search(gcs_timestamp = gcs_timestamp, connection_timestamp = connection_timestamp)
+            elif job_type == "guide":
+                # TODO
+                pass
+            else:
+                bad_msg(address, "Unknown jobType: \'" + job_type + "\'")
+
+        else:
+            bad_msg(address, "Unknown message type: \'" + msg_type + "\'")
+
+    # KeyError if message was missing an expected key
+    except KeyError as e:
+        bad_msg(address, "Missing \'" + e.args[0] + "\' key")
+
+def main():
+    configs = parse_configs(sys.argv)
+
+    # no comms simulation; that wouldn't be useful as this program is supposed to interact w/ GCS
+    global xbee
+    xbee = setup_xbee()
+
+    # send connection message
+    connection_message = {
+        "type": "connect",
+        "time": 0, # This field is currently not used
+        "jobsAvailable": ["quickScan", "detailedSearch", "guide"]
+    }
+
+    # Instantiate a remote XBee device object to send data.
+    send_xbee = RemoteXBeeDevice(xbee, address)
+    xbee.send_data(send_xbee, json.dumps(connection_message))
+
+    # wait to receive the connection ack and start message
+    xbee.add_data_received_callback(xbee_callback)
+
+if __name__ == "__main__":
+    main()

--- a/executable_picker.py
+++ b/executable_picker.py
@@ -62,6 +62,10 @@ def main():
     connection_message = {
         "type": "connect",
         "time": 0, # This field is currently not used
+        "sid": configs['vehicle_id'],
+        "tid": 0, # The ID of GCS
+        "id": 0, # The ID of this message
+
         "jobsAvailable": ["quickScan", "detailedSearch", "guide"]
     }
 

--- a/quick_scan.py
+++ b/quick_scan.py
@@ -36,13 +36,14 @@ class QuickScanAutonomyToCV:
         self.acknowledgementMutex = False
 
 
-def quick_scan():
+def quick_scan(gcs_timestamp = 0, connection_timestamp = 0):
     # Parse configs file
     configs = parse_configs(sys.argv)
 
     # Start autonomy and CV threads
     autonomyToCV = QuickScanAutonomyToCV()
-    autonomy_thread = Thread(target=quick_scan_autonomy, args=(configs, autonomyToCV))
+    autonomy_thread = Thread(target=quick_scan_autonomy,
+                             args=(configs, autonomyToCV, gcs_timestamp, connection_timestamp))
     autonomy_thread.daemon = True
     autonomy_thread.start()
 

--- a/quick_scan_autonomy.py
+++ b/quick_scan_autonomy.py
@@ -228,7 +228,7 @@ def quick_scan_autonomy(configs, autonomyToCV, gcs_timestamp, connection_timesta
     # Switch to detailed search if role switching is enabled
     if configs["quick_scan_specific"]["role_switching"]:
         autonomy.mission_completed = True
-        autonomy.updater.join()
+        update.join()
         detailed_search(vehicle)
     else:
         land(vehicle)

--- a/quick_scan_autonomy.py
+++ b/quick_scan_autonomy.py
@@ -183,7 +183,10 @@ def quick_scan_autonomy(configs, autonomyToCV, gcs_timestamp, connection_timesta
         sitl = dronekit_sitl.start_default(lat=1, lon=1)
         connection_string = sitl.connection_string()
     else:
-        connection_string = "/dev/serial0"
+        if (configs["3dr_solo"]):
+            connection_string = "udpin:0.0.0.0:14550"
+        else:
+            connection_string = "/dev/serial0"
 
     # Connect to vehicle
     vehicle = connect(connection_string, wait_ready=True)

--- a/quick_scan_autonomy.py
+++ b/quick_scan_autonomy.py
@@ -244,3 +244,4 @@ def quick_scan_autonomy(configs, autonomyToCV, gcs_timestamp, connection_timesta
     # Wait for comm simulation thread to end
     if comm_sim:
         comm_sim.join()
+    autonomy.xbee.close()

--- a/quick_scan_autonomy.py
+++ b/quick_scan_autonomy.py
@@ -244,4 +244,5 @@ def quick_scan_autonomy(configs, autonomyToCV, gcs_timestamp, connection_timesta
     # Wait for comm simulation thread to end
     if comm_sim:
         comm_sim.join()
-    autonomy.xbee.close()
+    else:
+        autonomy.xbee.close()


### PR DESCRIPTION
The new GCS message protocol uses the start message to determine the role of the vehicle e.g quick scan, detailed search, ...
This means that quick scan autonomy and detailed search autonomy shouldn't handle the start message, but instead a new program (executable picker) should handle the start message and run the corresponding VTOL program. This pull request creates the executable picker program.