### PR TITLE
fixes to the msgpack

### DIFF
--- a/autonomy.py
+++ b/autonomy.py
@@ -4,7 +4,9 @@ import subprocess
 import time
 from dronekit import connect, VehicleMode
 from pymavlink import mavutil
-from digi.xbee.devices import XBeeDevice, RemoteXBeeDevice
+from digi.xbee.devices import XBeeDevice, RemoteXBeeDevice, XBee64BitAddress
+import msgpack
+
 
 # Globals, updated by XBee callback function
 start_mission = False  # takeoff
@@ -206,8 +208,8 @@ def acknowledge(address, ackid, autonomyToCV):
     # xbee is None if comms is simulated
     if xbee:
         # Instantiate a remote XBee device object to send data.
-        send_xbee = RemoteXBeeDevice(xbee, address)
-        packed_data = packb(json.dumps(ack), use_bin_type = True)
+        send_xbee = RemoteXBeeDevice(xbee, XBee64BitAddress.from_hex_string(address))
+        packed_data = msgpack.packb(ack)
         autonomyToCv.xbeeMutex.acquire()
         xbee.send_data(send_xbee, packed_data)
         autonomyToCV.xbeeMutex.release()
@@ -230,8 +232,8 @@ def bad_msg(address, problem, autonomyToCV):
     # xbee is None if comms is simulated
     if xbee:
         # Instantiate a remote XBee device object to send data.
-        send_xbee = RemoteXBeeDevice(xbee, address)
-        packed_data = packb(json.dumps(msg, use_bin_type = True))
+        send_xbee = RemoteXBeeDevice(xbee, XBee64BitAddress.from_hex_string(address))
+        packed_data = msgpack.packb(msg)
         autonomyToCV.xbeeMutex.acquire()
         xbee.send_data(send_xbee, packed_Data)
         autonomyToCV.xbeeMutex.release()
@@ -248,7 +250,7 @@ def new_msg_id():
 
 def send_msg(address, msg):
     # Instantiate a remote XBee device object to send data.
-    send_xbee = RemoteXBeeDevice(xbee, address)
+    send_xbee = RemoteXBeeDevice(xbee, XBee64BitAddress.from_hex_string(address))
     xbee.send_data(send_xbee, json.dumps(msg))
 
 
@@ -320,8 +322,8 @@ def update_thread(vehicle, address, autonomyToCV):
 # Continuously sends message to given address until acknowledgement message is recieved with the corresponding ackid.
 def send_till_ack(address, msg, msg_id):
     # Instantiate a remote XBee device object to send data.
-    send_xbee = RemoteXBeeDevice(xbee, address)
-    packed_data = packb(json.dumps(ack), use_bin_type = True)
+    send_xbee = RemoteXBeeDevice(xbee, XBee64BitAddress.from_hex_string(address))
+    packed_data = bytearray(msgpack.packb(msg))
     while ack_id != msg_id:
         xbee.send_data(send_xbee, packed_data)
         time.sleep(1)

--- a/examples/send.py
+++ b/examples/send.py
@@ -3,10 +3,10 @@ from digi.xbee.devices import RemoteXBeeDevice
 from digi.xbee.models.address import XBee64BitAddress
 
 sys.path.append('..')
-from VTOL.autonomy import setup_xbee
+from autonomy import setup_xbee
 
 # Insert the MAC Address of desired radio here
-MAC_ADDR = "0013A200409BD79C"
+MAC_ADDR = "0013A20040F8064C"
 DATA_TO_SEND = "Hello XBee!"
 
 

--- a/executable_picker.py
+++ b/executable_picker.py
@@ -11,6 +11,7 @@ from util import parse_configs, new_output_file
 import sys
 import json
 import time
+import msgpack
 
 xbee = None
 gcs_timestamp = 0
@@ -21,14 +22,14 @@ def xbee_callback(message):
     global connection_timestamp
 
     address = message.remote_device.get_64bit_addr()
-    msg = json.loads(message.data)
+    msg = msgpack.unpackb(message.data)
     print("Received data from %s: %s" % (address, msg))
 
     try:
         msg_type = msg["type"]
 
         if msg_type == "connectionAck":
-            gcs_timestamp = msg['clocktime']
+            gcs_timestamp = msg["time"]
             connection_timestamp = time.time()
             autonomy.ack_id = msg["ackid"]
             


### PR DESCRIPTION
This fixes the msgpack issues.

Some problems I've been getting are the update messages not sending on scheduled basis.
The bad_msg() has 3 required parameters, the executable_picker calls it with only 2 parameters.
There are additional issues that I've been encountering after making the switch to the quick_scan; this error happens when the quick_scan tries to init & reconnect to the Xbee.
The error message is: `device reports readiness to read but returned no data (device disconnected or multiple access on port?)`